### PR TITLE
chira_collapse.py: change version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ChiRA - Chimeric Read Annotator
+# ChiRA - Chimeric Read Analyzer
 
 ChiRA is a set of tools to analyze RNA-RNA interactome experimental data such as CLASH, CLEAR-CLIP, PARIS, LIGR-Seq etc. Following are the descriptions of the each tool. Here we provide descriptions about the input and ouptput files. For the detailed description of the other parameters please look at the help texts of tools.
 

--- a/chira_collapse.py
+++ b/chira_collapse.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
                         help='Output fasta file')
     parser.add_argument("-u", '--umi_len', action='store', type=int, default=0, help="Length of the UMI, if present."
                         "It is trimmed from the 5' end of each read and appended to the tag id")
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.1.5')
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.2.0')
 
     args = parser.parse_args()
     print('Input FASTQ          : ' + args.fastq)

--- a/chira_map.py
+++ b/chira_map.py
@@ -2,22 +2,19 @@
 import argparse
 import os
 import sys
-from collections import defaultdict
 import pysam
-from multiprocessing import Process
-import logging
-import datetime
-import math
 import chira_utilities
 
-def align_with_bwa(align_type, index_type, fasta, refindex, outdir, seed_length, align_score, processes):
+
+def align_with_bwa(align_type, index_type, query_fasta, refindex, outdir, seed_length, align_score,
+                   macth_score, mistmatch_score, gap_o, gap_e, n_aligns, processes):
     """
         Funtion that maps the reads to the transcriptome. Different parameters
         are used for long and short alignments.
         Parameters:
             align_type: String of alignmnet type (long or short) used to format the output file name.
             index_type: String of index1 type (index1 or index2) used to format the output file name.
-            fasta: Path to query fasta file. For align_type short, long.unmapped.fa from the out_dir used.
+            query_fasta: Path to query fasta file. For align_type short, long.unmapped.fa from the out_dir used.
             refindex: Path to the reference index file.
             outdir: Output directory path.
             seed_length: Minimum seed length
@@ -25,32 +22,22 @@ def align_with_bwa(align_type, index_type, fasta, refindex, outdir, seed_length,
             processes: Number of processes to use
     """
 
-    logging.info("| STRAT: Mapping " + align_type + "reads segments to " + index_type + " at " + refindex)
-
-    query_fasta = mismatch_score = gap_o = gap_e = n_aligns = None
     bam = os.path.join(outdir, index_type + "." + align_type + ".bam")
 
     if align_type == "long":
-        query_fasta = fasta
-        mismatch_score = "4"
         n_aligns = "50"
-        gap_o = "6"
-        gap_e = "1"
     elif align_type == "short":
-        query_fasta = os.path.join(outdir, "long.unmapped.fa")
-        mismatch_score = "100"
         n_aligns = "100"
-        gap_o = "100"
-        gap_e = "100"
 
     bwa_params = ["-r 1",                       # look for internal seeds inside a seed longer than {-k} * {-r}
                   "-c 1000",
-                  "-B " + mismatch_score,       # mismatch penalty
-                  "-O " + gap_o,                # gap open penalty
-                  "-E " + gap_e,                # gap extension penalty
+                  "-A "+ str(macth_score),          # match score
+                  "-B " + str(mistmatch_score),       # mismatch penalty
+                  "-O " + str(gap_o),                # gap open penalty
+                  "-E " + str(gap_e),                # gap extension penalty
                   "-L 0",                       # clipping penalty, we need soft clips
                   "-Y",                         # use soft clipping for supplementary alignments
-                  "-h " + n_aligns,             # if there're -h hits with score >80% of the maxscore, output in XA
+                  "-h " + str(n_aligns),             # if there're -h hits with score >80% of the maxscore, output in XA
                   "-k " + str(seed_length),     # minimum seed length
                   "-T " + str(align_score),     # minimum alignment score
                   "-t " + str(processes),
@@ -60,146 +47,67 @@ def align_with_bwa(align_type, index_type, fasta, refindex, outdir, seed_length,
     bwacall = ("bwa mem " + " ".join(bwa_params) + " | samtools view -hb - > " + bam)
     print(bwacall)
     os.system(bwacall)
-    logging.info("| END: Mapping " + align_type + "reads segments to " + index_type + " at " + refindex)
 
 
-def merge_bams(outdir, align_type, processes):
-    logging.info("| START: merge and sort " + align_type + " alignments of both indices")
-    # -f to force if file already exists
-    pysam.merge("-f",  os.path.join(outdir, align_type + ".unsorted.bam"),
-                os.path.join(outdir, "index1." + align_type + ".bam"),
-                os.path.join(outdir, "index2." + align_type + ".bam"))
-    pysam.sort("-m", "1G", "-@", str(processes),
-               os.path.join(outdir, align_type + ".unsorted.bam"),
-               "-T", os.path.join(outdir, align_type),
-               "-o", os.path.join(outdir, align_type + ".bam"))
-    pysam.index(os.path.join(outdir, align_type + ".bam"))
-    os.path.join(outdir, align_type + ".unsorted.bam")
-    if os.path.exists(os.path.join(outdir, "index1." + align_type + ".bam")):
-        os.remove(os.path.join(outdir, "index1." + align_type + ".bam"))
-    if os.path.exists(os.path.join(outdir, "index2." + align_type + ".bam")):
-        os.remove(os.path.join(outdir, "index2." + align_type + ".bam"))
-    os.remove(os.path.join(outdir, align_type + ".unsorted.bam"))
-    logging.info("| END: merge and sort " + align_type + " alignments both indices")
-
-
-def extract_singleton_reads(s, e, d_read_positions, co, d_mapped_reads, singletons_fasta, i):
+def write_mapped_bed(bam, bed, fasta, stranded):
     """
-        For long alignments, this function to checks if there is at least an alignment per read
-        with 2 non-overlapping arms. If there such an alignment, read qualifies as chimeric.
-        Otherwise, as singleton and added to the given dictionary.
+        Extracts the mapped and unmapped reads from the BAM alignments and writes them to BED and fasta files
         Parameters:
-            s: Start index of the chunk
-            e: End index of the chunk
-            d_read_positions: Dictionaries containing  the  [readid] -> [(read_sart, read_end; reference_id)]
-            co: Maximum allowed overlap between the aligned read arms
-            d_mapped_reads: dictionary containing all the mapped sequences
-            singletons_fasta: File path to write singleton fasta sequences temporarily
-            i: index to add to fasta file indicating the process count
-    """
-    d_singleton_reads = defaultdict(list)
-    l_proper_chimeric_reads = []
-    for readid in list(d_read_positions)[s:e]:
-        if readid in l_proper_chimeric_reads:
-            continue
-        proper_chimera = False
-        for (read_start, read_end, ref_id) in d_read_positions[readid]:
-            # mark as unmapped if there is only one mapped segment that doesn't cover the entire read
-            if readid in d_singleton_reads:
-                for prev_pos in d_singleton_reads[readid]:
-                    # same reference id
-                    # TODO: accept as a proper chimera if its mapped parts are not overlapping
-                    if ref_id == prev_pos[2]:
-                        continue
-                    # <= co indicates no overlap between read segments,
-                    # a second non-overlapping soft clipped alignment found
-                    if chira_utilities.overlap([prev_pos[0], prev_pos[1]], [read_start, read_end]) <= co:
-                        proper_chimera = True
-                        break
-            if proper_chimera:
-                l_proper_chimeric_reads.append(readid)
-                if readid in d_singleton_reads:
-                    del d_singleton_reads[readid]
-            else:
-                if [read_start, read_end, ref_id] not in d_singleton_reads[readid]:
-                    d_singleton_reads[readid].append([read_start, read_end, ref_id])
-
-    with open(singletons_fasta + "." + i, "w") as fh_singletons:
-        for readid in d_singleton_reads.keys():
-            fh_singletons.write(">" + readid + "\n" + d_mapped_reads[readid] + "\n")
-
-
-def extract_unmapped(align_type, outdir, chimeric_overlap, stranded, processes):
-    """
-        Extracts the unmapped and singlton reads from the BAM alignments and writes them to a file
-        Parameters:
-            align_type: String of alignmnet type (long or short) used to get the BAM file path.
-            outdir: Output directory path.
-            chimeric_overlap: Maximum number of bases allowed between the chimeric segments of a read
+            bam: BAM file containing all merged alignments
+            bed: output BED file path
+            fasta: output FASTA file path
             stranded: Strand specificity
-            processes: Number of processes
     """
-    logging.info("| START: extract unmapped reads of " + align_type + " alignments")
-    fh_bam = pysam.Samfile(os.path.join(outdir, align_type + ".bam"), "rb")
-    fh_mapped_bam = pysam.Samfile(os.path.join(outdir, align_type + ".mapped.bam"), "wb",
-                                  template=fh_bam)
-    fh_mapped_bed = open(os.path.join(outdir, align_type + ".mapped.bed"), "w")
-    d_mapped_reads = defaultdict(str)
-    d_unmapped_reads = defaultdict(str)
-    d_read_positions = defaultdict(list)  # contains a tuple of matched base positions on the read and reference id
-    for alignment in fh_bam.fetch(until_eof=True):
-        readid = alignment.query_name
-        readseq = None
-        if alignment.is_reverse:
-            readseq = chira_utilities.reverse_complement(alignment.query_sequence)
-        else:
-            readseq = alignment.query_sequence
-        proper_stranded_align_found = False
-        if alignment.is_unmapped or \
-                (stranded == "fw" and alignment.is_reverse and not alignment.has_tag('XA')) or \
-                (stranded == "rc" and not alignment.is_reverse and not alignment.has_tag('XA')):
-            if readid not in d_mapped_reads:
-                if readseq:
-                    d_unmapped_reads[readid] = readseq
-                else:
-                    d_unmapped_reads[readid] = d_mapped_reads[readid]
-        else:
-            if readid in d_unmapped_reads:
-                del d_unmapped_reads[readid]
-            d_mapped_reads[readid] = readseq
-            fh_mapped_bam.write(alignment)
-            # in this case there might be alignments on wrong strand with XA tag
-            # hence, write the alignment only if it mapped on desired strand
-            optimal_match_len = 0
-            if (stranded == "rc" and alignment.is_reverse) or (stranded == "fw" and not alignment.is_reverse):
-                fh_mapped_bed.write(chira_utilities.bedentry(fh_bam.getrname(alignment.tid),
+    prev_readid = None
+    prev_fasta = ""
+    prev_unmapped = True
+    with pysam.Samfile(bam, "rb") as fh_bam, open(bed, "w") as fh_mapped_bed, open(fasta, "w") as fh_unmapped_fasta:
+        for alignment in fh_bam.fetch(until_eof=True):
+            readid = alignment.query_name
+            if readid != prev_readid:
+                if prev_unmapped:
+                    fh_unmapped_fasta.write(prev_fasta)
+                prev_unmapped = True
+
+            readseq = alignment.get_forward_sequence()
+
+            prev_fasta = ">" + readid + "\n" + readseq + "\n"
+            prev_readid = readid
+
+            if alignment.is_unmapped:
+                continue
+            optimal_alignment_len = 0
+            # write the alignment only if it mapped on desired strand
+            if (stranded == "rc" and alignment.is_reverse) or \
+                    (stranded == "fw" and not alignment.is_reverse) or \
+                    stranded == "both":
+                fh_mapped_bed.write(chira_utilities.bedentry(alignment.reference_name,
                                                              str(alignment.reference_start),
                                                              str(alignment.reference_end),
                                                              readid,
                                                              "-" if alignment.is_reverse else "+",
                                                              alignment.cigarstring) + "\n")
-                d_read_positions[readid].append([alignment.query_alignment_start,
-                                                alignment.query_alignment_end,
-                                                fh_bam.getrname(alignment.tid)])
-                proper_stranded_align_found = True
-                optimal_match_len = chira_utilities.alignment_score(alignment.cigarstring, alignment.get_tag("NM"))
-            # XA tag only present in bwa output
+                prev_unmapped = False
+                optimal_alignment_len = alignment.query_alignment_length
+
+            # XA tag present in bwa output only
             if not alignment.has_tag('XA'):
                 continue
 
             alt_alignments = alignment.get_tag('XA').rstrip(';').split(';')
-            # either optimal_match_len already set or there must be at least a secondary alignment on desired strand
-            if optimal_match_len == 0:
-                for alt_alignment in alt_alignments:
-                    f_alt_align = alt_alignment.split(',')
-                    if f_alt_align[1].startswith('-'):
-                        continue
-                    alt_cigar = f_alt_align[2]
-                    alt_nm = int(f_alt_align[3])
-                    alt_match_len = chira_utilities.alignment_score(alt_cigar, alt_nm)
-                    if alt_match_len > optimal_match_len:
-                        optimal_match_len = alt_match_len
-
+            # either optimal_alignment_len already set or there must be at least a secondary alignment on desired strand
+            # if optimal_alignment_len == 0:
+            for alt_alignment in alt_alignments:
+                f_alt_align = alt_alignment.split(',')
+                # check if it mapped on desired strand
+                if (f_alt_align[1].startswith('-') and stranded == "fw") or \
+                        (f_alt_align[1].startswith('+') and stranded == "rc"):
+                    continue
+                alt_cigar = f_alt_align[2]
+                alt_nm = int(f_alt_align[-1])
+                alt_alignment_len = chira_utilities.alignment_length(alt_cigar)
+                if alt_alignment_len > optimal_alignment_len:
+                    optimal_alignment_len = alt_alignment_len
             # now examine XA tag for alternate alignments
             for alt_alignment in alt_alignments:
                 f_alt_align = alt_alignment.split(',')
@@ -211,14 +119,10 @@ def extract_unmapped(align_type, outdir, chimeric_overlap, stranded, processes):
                 alt_refstart = f_alt_align[1][1:]
                 alt_refstrand = f_alt_align[1][0]
                 alt_cigar = f_alt_align[2]
-                alt_nm = int(f_alt_align[3])
                 alt_refend = chira_utilities.alignment_end(alt_refstart, alt_cigar, f_alt_align[1].startswith("-"))
+                alt_alignment_len = chira_utilities.alignment_length(alt_cigar)
 
-                alt_read_start, alt_read_end = chira_utilities.match_positions(alt_cigar,
-                                                                               f_alt_align[1].startswith("-"))
-                alt_match_len = chira_utilities.alignment_score(alt_cigar, alt_nm)
-                # TODO an option to consider Suboptimal alignments by a threshold
-                if alt_match_len < optimal_match_len:
+                if alt_alignment_len < optimal_alignment_len:
                     continue
                 fh_mapped_bed.write(chira_utilities.bedentry(alt_referenceid,
                                                              str(int(alt_refstart)-1),
@@ -226,84 +130,25 @@ def extract_unmapped(align_type, outdir, chimeric_overlap, stranded, processes):
                                                              readid,
                                                              alt_refstrand,
                                                              alt_cigar) + "\n")
-                d_read_positions[readid].append([alt_read_start, alt_read_end, alt_referenceid])
-                proper_stranded_align_found = True
-            # if there is not a single alignment on desired strand then consider the read as unmapped
-            if not proper_stranded_align_found:
-                if readid not in d_mapped_reads:
-                    if readseq:
-                        d_unmapped_reads[readid] = readseq
-                    else:
-                        d_unmapped_reads[readid] = d_mapped_reads[readid]
-    fh_bam.close()
-    fh_mapped_bam.close()
-    fh_mapped_bed.close()
+                prev_unmapped = False
 
-    if align_type == "short":
-        with open(os.path.join(outdir, align_type + ".unmapped.fa"), "w") as fh_unmapped_fasta:
-            for readid, readseq in d_unmapped_reads.items():
-                fh_unmapped_fasta.write(">" + readid + "\n" + readseq + "\n")
-        return
-    # further process long mapped reads
-    jobs = []
-    print(str(datetime.datetime.now()), " START: multiprocessing")
-    singletons_fasta = os.path.join(args.outdir, "siingleton_reads")
-    for i in range(processes):
-        s = i * math.ceil(len(d_read_positions)/processes)
-        e = min(s + math.ceil(len(d_read_positions)/processes), len(d_read_positions))
-        j = Process(target=extract_singleton_reads,
-                    args=(s, e, d_read_positions, chimeric_overlap, d_mapped_reads, singletons_fasta, str(i)))
-        jobs.append(j)
-        j.start()
-    for j in jobs:
-        j.join()
-    print(str(datetime.datetime.now()), " END: multiprocessing")
-    # write all unmapped sequences to a fasta file
-    with open(os.path.join(outdir, align_type + ".unmapped.fa"), "w") as fh_unmapped_fasta:
-        for readid, readseq in d_unmapped_reads.items():
-            fh_unmapped_fasta.write(">" + readid + "\n" + readseq + "\n")
-        for n in range(processes):
-            with open(singletons_fasta + "." + str(n)) as infile:
-                for line in infile:
-                    fh_unmapped_fasta.write(line)
-            os.remove(singletons_fasta + "." + str(n))
-    logging.info("| END: extract unmapped reads of " + align_type + " alignments")
-    return
-
-
-def merge_beds(long_mapped_bed, short_mapped_bed, mapped_bed):
-    """
-    Merge long and short mapped BED entries. There are chances that both long and
-    short alignment settings lead to same alignments for some reads.
-
-    Parameters:
-       long_mapped_bed: Path to long mapped BED file
-       short_mapped_bed: Path to short mapped BED file
-       mapped_bed: Path to final output mapped BED file
-    """
-
-    lines1 = set(l for l in open(long_mapped_bed).read().splitlines())
-    with open(mapped_bed, "w") as fh_out:
-        for l in lines1:
-            fh_out.write(l + "\n")
-        with open(short_mapped_bed) as fh_short:
-            for line in fh_short:
-                if line.rstrip("\n") in lines1:
-                    continue
-                fh_out.write(line)
+        if prev_unmapped:
+            fh_unmapped_fasta.write(prev_fasta)
 
 
 def align_with_clan(query_fasta, outdir, ref_fasta1, ref_index1, ref_fasta2, ref_index2,
-                    chimeric_overlap, align_score, stranded, processes):
-    logging.info("| START: Mapping reads using CLAN")
+                    chimeric_overlap, align_score, stranded, n_aligns, processes):
 
     ref_index = "-f " + ref_fasta1 + " -d " + ref_index1
     if ref_fasta2 and ref_index2:
         ref_index += " -F " + ref_fasta2 + " -D " + ref_index2
-    n_aligns = 100
+    map_to_both_strands = "FALSE"
+    if stranded == "both":
+        map_to_both_strands = "TRUE"
     clan_search_params = ["-r " + query_fasta,          # query fasta file
                           "-m " + str(n_aligns),        # number of maximum hits for each maximal fragment
                           "-l " + str(align_score),     # minimum length for each fragment
+                          "-s " + map_to_both_strands,
                           "-t " + str(processes),
                           "-v " + str(chimeric_overlap),
                           "-o " + os.path.join(outdir, "out.clan"),
@@ -311,7 +156,6 @@ def align_with_clan(query_fasta, outdir, ref_fasta1, ref_index1, ref_fasta2, ref
     clan_search = ("clan_search " + " ".join(clan_search_params))
     print(clan_search)
     os.system(clan_search)
-    logging.info("| END: Mapping reads using CLAN")
 
     ref_fasta = "-f " + ref_fasta1
     if ref_fasta2 and ref_index2:
@@ -324,7 +168,7 @@ def align_with_clan(query_fasta, outdir, ref_fasta1, ref_index1, ref_fasta2, ref
     clan_output = ("clan_output " + " ".join(clan_output_params))
     print(clan_output)
     os.system(clan_output)
-
+    return
 
 def clan_to_bed(outdir):
     with open(os.path.join(outdir, "out.map")) as fh_in, open(os.path.join(outdir, "mapped.bed"), "w") as fh_out:
@@ -350,17 +194,10 @@ def clan_to_bed(outdir):
                 # if header has spaces select the id only
                 ref_id = ":".join(d[0:-1]).split(' ')[0]
                 [ref_start, ref_end] = d[-1].split("-")
-                # TODO: consider both strands
+                # NOTE: at the moment there is no way to findout which strand it is mapping to
                 fh_out.write("\t".join([ref_id, str(int(ref_start)-1), ref_end,
                                         ",".join([read_id, ref_id, str(int(ref_start)-1), ref_end, "+", cigar]),
                                         "1", "+"]) + "\n")
-
-
-def score_float(x):
-    x = float(x)
-    if x < 0.0 or x > 1.0:
-        raise argparse.ArgumentTypeError("%r not in range [0.0, 1.0]" % (x,))
-    return x
 
 
 if __name__ == "__main__":
@@ -425,11 +262,51 @@ if __name__ == "__main__":
                                 It must be smaller than --align_score1 parameter.
                                 bwa-mem parameter "-T" and clan_search parameter "-l"''')
 
+    parser.add_argument("-ma1", '--match1', action='store', type=int, default=1, metavar='',
+                        dest='match1',
+                        help='Matching score for 1st mapping iteration.')
+
+    parser.add_argument("-mm1", '--mismatch1', action='store', type=int, default=4, metavar='',
+                        dest='mismatch1',
+                        help='Mismatch penalty for 1st mapping iteration.')
+
+    parser.add_argument("-ma2", '--match2', action='store', type=int, default=1, metavar='',
+                        dest='match2',
+                        help='Matching score for 2nd mapping iteration.')
+
+    parser.add_argument("-mm2", '--mismatch2', action='store', type=int, default=7, metavar='',
+                        dest='mismatch2',
+                        help='Mismatch penalty for 2nd mapping iteration.')
+
+    parser.add_argument("-go1", '--gapopen1', action='store', type=int, default=6, metavar='',
+                        dest='gapopen1',
+                        help='Gap opening penalty for 1st mapping iteration.')
+
+    parser.add_argument("-ge1", '--gapext1', action='store', type=int, default=1, metavar='',
+                        dest='gapext1',
+                        help='Gap extension penalty for 1st mapping iteration.')
+
+    parser.add_argument("-go2", '--gapopen2', action='store', type=int, default=100, metavar='',
+                        dest='gapopen2',
+                        help='Gap opening penalty for 2nd mapping iteration.')
+
+    parser.add_argument("-ge2", '--gapext2', action='store', type=int, default=100, metavar='',
+                        dest='gapext2',
+                        help='Gap extension penalty for 2nd mapping iteration.')
+
+    parser.add_argument("-h1", '--nhits1', action='store', type=int, default=50, metavar='',
+                        dest='nhits1',
+                        help='Number of allowed multi hits per read')
+
+    parser.add_argument("-h2", '--nhits2', action='store', type=int, default=100, metavar='',
+                        dest='nhits2',
+                        help='Number of allowed multi hits per read in 2nd iteration')
+
     parser.add_argument('-co', '--chimeric_overlap', action='store', type=int, default=2, metavar='',
                         dest='chimeric_overlap',
                         help='Maximum number of bases allowed between the chimeric segments of a read')
 
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.1.5')
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.2.0')
 
     args = parser.parse_args()
     print('Query fasta                          : ' + args.fasta)
@@ -481,10 +358,16 @@ if __name__ == "__main__":
             if args.ref_fasta2:
                 index2 = os.path.join(args.outdir, "index2")
                 os.system("clan_index -f " + args.ref_fasta2 + " -d " + index2)
+
         # use only align_score2 for mapping with CLAN
+        chira_utilities.print_w_time("STRAT: Map read using CLAN")
         align_with_clan(args.fasta, args.outdir, args.ref_fasta1, index1, args.ref_fasta2, index2,
-                        args.chimeric_overlap, args.align_score2, args.stranded, args.processes)
+                        args.chimeric_overlap, args.align_score2, args.stranded, args.nhits2, args.processes)
+        chira_utilities.print_w_time("END: Map read using CLAN")
+        chira_utilities.print_w_time("START: Write alignments to BED")
         clan_to_bed(args.outdir)
+        chira_utilities.print_w_time("END: Write alignments to BED")
+
     elif args.aligner == "bwa":
         # build indices
         if args.build_index:
@@ -493,69 +376,73 @@ if __name__ == "__main__":
             if args.ref_fasta2:
                 index2 = os.path.join(args.outdir, "index2")
                 os.system("bwa index -p " + index2 + " " + args.ref_fasta2)
+
         # align with bwa
-        align_with_bwa("long", "index1", args.fasta, index1,  args.outdir,
-                       args.seed_length1, args.align_score1, args.processes)
+        chira_utilities.print_w_time("STRAT: Map long read segments to index1 at " + index1)
+        align_with_bwa("long", "index1", args.fasta, index1, args.outdir, args.seed_length1, args.align_score1,
+                       args.match1, args.mismatch1, args.gapopen1, args.gapext1, args.nhits1, args.processes)
+        chira_utilities.print_w_time("END: Map long read segments to index1 at " + index1)
+
+        chira_utilities.print_w_time("STRAT: Map short read segments to index1 at " + index1)
+        align_with_bwa("short", "index1", args.fasta, index1, args.outdir, args.seed_length2, args.align_score2,
+                       args.match2, args.mismatch2, args.gapopen2, args.gapext2, args.nhits2, args.processes)
+        chira_utilities.print_w_time("END: Map short read segments to index1 at " + index1)
+
         if index2:
-            align_with_bwa("long", "index2", args.fasta, index2, args.outdir,
-                           args.seed_length1, args.align_score1, args.processes)
-            # if 2 indices given, merge bams from both indices and sort
-            # TODO: handle cases where nothing maps to index1 or index2 and try to merge empty bam files
-            merge_bams(args.outdir, "long", args.processes)
+            chira_utilities.print_w_time("STRAT: Map long read segments to index2 at " + index2)
+            align_with_bwa("long", "index2", args.fasta, index2, args.outdir, args.seed_length1, args.align_score1,
+                           args.match1, args.mismatch1, args.gapopen1, args.gapext1, args.nhits1, args.processes)
+            chira_utilities.print_w_time("END: Map long read segments to index2 at " + index2)
+            chira_utilities.print_w_time("STRAT: Map short read segments to index2 at " + index2)
+            align_with_bwa("short", "index2", args.fasta, index2, args.outdir, args.seed_length2, args.align_score2,
+                           args.match2, args.mismatch2, args.gapopen2, args.gapext2, args.nhits2, args.processes)
+            chira_utilities.print_w_time("END: Map short read segments to index2 at " + index2)
+
+            chira_utilities.print_w_time("STRAT: Merge BAM files")
+            # -f to force if file already exists
+            pysam.merge("-f", "-@", str(args.processes),
+                        os.path.join(args.outdir, "unsorted.bam"),
+                        os.path.join(args.outdir, "index1.long.bam"),
+                        os.path.join(args.outdir, "index1.short.bam"),
+                        os.path.join(args.outdir, "index2.long.bam"),
+                        os.path.join(args.outdir, "index2.short.bam"))
+            chira_utilities.print_w_time("END: Merge BAM files")
         else:
-            logging.info("| START: sort long alignments")
-            # if only  one index given just sort it
-            pysam.sort("-m", "1G", "-@", str(args.processes),
-                       os.path.join(args.outdir, "index1.long.bam"),
-                       "-T", os.path.join(args.outdir, "index1.long"),
-                       "-o", os.path.join(args.outdir, "long.bam"))
-            pysam.index(os.path.join(args.outdir, "long.bam"))
-            logging.info("| END: sort long alignments")
-        print(str(datetime.datetime.now()), " START:extract unmapped long")
-        extract_unmapped("long", args.outdir, args.chimeric_overlap, args.stranded, args.processes)
-        if os.path.exists(os.path.join(args.outdir, "long.bam")):
-            os.remove(os.path.join(args.outdir, "long.bam"))
+            chira_utilities.print_w_time("START: Merge BAM files")
+            # -f to force if file already exists
+            pysam.merge("-f", "-@", str(args.processes),
+                        os.path.join(args.outdir, "unsorted.bam"),
+                        os.path.join(args.outdir, "index1.long.bam"),
+                        os.path.join(args.outdir, "index1.short.bam"))
+            chira_utilities.print_w_time("END: Merge BAM files")
+        try:
+            os.remove(os.path.join(args.outdir, "index1.long.bam"))
+            os.remove(os.path.join(args.outdir, "index1.short.bam"))
+            os.remove(os.path.join(args.outdir, "index2.long.bam"))
+            os.remove(os.path.join(args.outdir, "index2.short.bam"))
+        except OSError:
+            pass
 
-        print(str(datetime.datetime.now()), " START:extract unmapped long")
-        align_with_bwa("short", "index1", args.fasta, index1, args.outdir,
-                       args.seed_length2, args.align_score2, args.processes)
-        if index2:
-            align_with_bwa("short", "index2", args.fasta, index2, args.outdir,
-                           args.seed_length2, args.align_score2, args.processes)
-            # if 2 indices given, merge bams from both indices and sort
-            merge_bams(args.outdir, "short", args.processes)
-        else:
-            logging.info("| START: sort short alignments")
-            # if only  one index given just sort it
-            pysam.sort("-m", "1G", "-@", str(args.processes),
-                       os.path.join(args.outdir, "index1.short.bam"),
-                       "-T", os.path.join(args.outdir, "index1.short"),
-                       "-o", os.path.join(args.outdir, "short.bam"))
-            pysam.index(os.path.join(args.outdir, "short.bam"))
-            logging.info("| END: sort short alignments")
-        extract_unmapped("short", args.outdir, args.chimeric_overlap, args.stranded, args.processes)
-        if os.path.exists(os.path.join(args.outdir, "short.bam")):
-            os.remove(os.path.join(args.outdir, "short.bam"))
+        chira_utilities.print_w_time("START: Sorting BAM file")
+        pysam.sort("-m", "1G", "-@", str(args.processes), "-n",
+                   os.path.join(args.outdir, "unsorted.bam"),
+                   "-T", os.path.join(args.outdir, "sorted"),
+                   "-o", os.path.join(args.outdir, "sorted.bam"))
+        chira_utilities.print_w_time("END: Sorting BAM file")
+        os.remove(os.path.join(args.outdir, "unsorted.bam"))
 
-        logging.info("| START: merge both long and short alignments")
-        merge_beds(os.path.join(args.outdir, "long.mapped.bed"),
-                   os.path.join(args.outdir, "short.mapped.bed"),
-                   os.path.join(args.outdir, "mapped.bed"))
-        if os.path.exists(os.path.join(args.outdir, "long.mapped.bed")):
-            os.remove(os.path.join(args.outdir, "long.mapped.bed"))
-        if os.path.exists(os.path.join(args.outdir, "short.mapped.bed")):
-            os.remove(os.path.join(args.outdir, "short.mapped.bed"))
-
-        # -f to force if file already exists
-        pysam.merge("-f", os.path.join(args.outdir, "mapped.bam"),
-                    os.path.join(args.outdir, "long.mapped.bam"),
-                    os.path.join(args.outdir, "short.mapped.bam"))
-        if os.path.exists(os.path.join(args.outdir, "long.mapped.bam")):
-            os.remove(os.path.join(args.outdir, "long.mapped.bam"))
-        if os.path.exists(os.path.join(args.outdir, "short.mapped.bam")):
-            os.remove(os.path.join(args.outdir, "short.mapped.bam"))
-
-        logging.info("| END: merge both long and short alignments")
+        chira_utilities.print_w_time("START: Write alignments to BED")
+        write_mapped_bed(os.path.join(args.outdir, "sorted.bam"),
+                         os.path.join(args.outdir, "mapped.bed"),
+                         os.path.join(args.outdir, "unmapped.fasta"),
+                         args.stranded)
+        chira_utilities.print_w_time("END: Write alignments to BED")
     else:
         sys.stderr.write("Unknown aligner!! Currently suppoted aligners: BWA-mem and CLAN")
         sys.exit(1)
+
+    chira_utilities.print_w_time("START: Sorting BED file")
+    os.system("sort -k 4,4 -u " + os.path.join(args.outdir, "mapped.bed")
+              + ">" + os.path.join(args.outdir, "sorted.bed"))
+    chira_utilities.print_w_time("END: Sorting BED file")
+    os.remove(os.path.join(args.outdir, "mapped.bed"))

--- a/chira_quantify.py
+++ b/chira_quantify.py
@@ -2,13 +2,12 @@
 import os
 import sys
 from collections import defaultdict
-import datetime
 import argparse
 import chira_utilities
 sys.setrecursionlimit(10000)
 
 
-def create_crls(create_crls_too, bed, merged_bed, crl_file, crl_share, min_locus_size):
+def build_crls(build_crls_too, bed, merged_bed, crl_file, crl_share_cutoff, min_locus_size):
     l_locilen = []
     l_locipos = []
     l_locireads = []
@@ -35,11 +34,11 @@ def create_crls(create_crls_too, bed, merged_bed, crl_file, crl_share, min_locus
     d_crl_reads = defaultdict(list)
     d_crl_locus_reads = defaultdict(lambda: defaultdict())
     l_remaining_locireads = defaultdict(list)
-    print(str(datetime.datetime.now()), "start 1st iteration of CRLs")
+    chira_utilities.print_w_time("START: 1st iteration of CRLs")
     print("Number of loci: " + str(len(l_locireads)))
     n_crl = 0
     # create CRLs only if required
-    if create_crls_too:
+    if build_crls_too:
         l_qualified_locireads = sorted([(i, item) for i, item in enumerate(l_locireads) if len(item) >= min_locus_size],
                                        key=lambda x: len(x[1]), reverse=True)
         l_remaining_locireads = sorted([(i, item) for i, item in enumerate(l_locireads) if len(item) < min_locus_size],
@@ -50,26 +49,26 @@ def create_crls(create_crls_too, bed, merged_bed, crl_file, crl_share, min_locus
         for n_locus, l_locusreads in l_qualified_locireads:
             already_crl_member = False
             l_matched_crls = []
-            # substraction of 0.1 is a heuristic to loosly filter out the loci
-            lower_bound = len(l_locusreads) * (crl_share - 0.1)
-            upper_bound = len(l_locusreads) / (crl_share - 0.1)
+            # substraction of 0.1 is a heuristic to loosly filter out the loci based on size
+            lower_bound = len(l_locusreads) * (crl_share_cutoff - 0.1)
+            upper_bound = len(l_locusreads) / (crl_share_cutoff - 0.1)
             # traverse in reverse order because the latest CRL is the last one
             for crlid in range(len(d_crl_reads) - 1, 0, -1):
                 l_crlreads = set(d_crl_reads[crlid])
+                # if the CRL has similar size
                 if lower_bound <= len(l_crlreads) <= upper_bound:
                     # if there are significantly more reads in crl than in locus or otherway around
                     n_common_reads = len(l_locusreads.intersection(l_crlreads))
                     if n_common_reads == 0:
                         continue
                     n_union_reads = len(l_crlreads.union(l_locusreads))
-                    # jaccard similarity score, skip the whole crl even if one of the locus doesn't overlap enough
-                    if n_common_reads / float(n_union_reads) < crl_share:
+                    # jaccard similarity score
+                    if n_common_reads / float(n_union_reads) < crl_share_cutoff:
                         continue
                     # identical loci are multi-mapped loci with the same set of identical set of multi-mapped reads
                     l_matched_crls.append(crlid)
                     already_crl_member = True
-                else:
-                    break
+
             # n_locus is not a member of any crl, hence create a new crl
             if not already_crl_member:
                 l_matched_crls.append(n_crl)
@@ -86,9 +85,10 @@ def create_crls(create_crls_too, bed, merged_bed, crl_file, crl_share, min_locus
     for n_locus, l_locusreads in l_remaining_locireads:
         d_crl_locus_reads[n_crl][n_locus] = l_locusreads
         n_crl += 1
-    print(str(datetime.datetime.now()), " done 1st iteration of CRLs")
+    chira_utilities.print_w_time("END: 1st iteration of CRLs")
 
     d_locus_crl_share = defaultdict(lambda: defaultdict(float))
+    d_highest_shares = defaultdict(float)
     for crlid, d_crlloci in d_crl_locus_reads.items():
         l_crlreads = []
         for l_locusreads in d_crlloci.values():
@@ -96,25 +96,29 @@ def create_crls(create_crls_too, bed, merged_bed, crl_file, crl_share, min_locus
         for locusid, l_locusreads in d_crlloci.items():
             locus_share = len(l_locusreads) / float(len(set(l_crlreads)))
             d_locus_crl_share[locusid][crlid] = locus_share
+            if locus_share > d_highest_shares[locusid]:
+                d_highest_shares[locusid] = locus_share
 
     d_isolated_loci = {}  # loci that are separated from crl because of not enough overall share
-    print(str(datetime.datetime.now()), "start 2st iteration of CRLs")
+    chira_utilities.print_w_time("START: 2st iteration of CRLs")
     # in this iteration each locus is checked again for crl share and only one best crl for locus kept
     # if there are multiple eqaully good crls for a locus, all of the crls are considered for that locus
-    for crlid, d_crlloci in d_crl_locus_reads.items():
+    for crlid in list(d_crl_locus_reads.keys()):
+        d_crlloci = d_crl_locus_reads[crlid]
         for locusid in list(d_crlloci):
-            if d_locus_crl_share[locusid][crlid] >= crl_share:
-                for any_crlid in d_locus_crl_share[locusid]:
-                    if d_locus_crl_share[locusid][crlid] < d_locus_crl_share[locusid][any_crlid]:
-                        if locusid in d_crl_locus_reads[crlid]:
-                            del d_crl_locus_reads[crlid][locusid]
+            if d_locus_crl_share[locusid][crlid] >= crl_share_cutoff:
+                if d_locus_crl_share[locusid][crlid] < d_highest_shares[locusid]:
+                    if locusid in d_crl_locus_reads[crlid]:
+                        del d_crl_locus_reads[crlid][locusid]
+                        # del d_locus_crl_share[locusid][crlid]
             else:
                 # store isolated locus id and its reads
                 d_isolated_loci[locusid] = d_crlloci[locusid]
                 del d_crl_locus_reads[crlid][locusid]
-    print(str(datetime.datetime.now()), "End: finding isolated CRL loci")
-    print(str(datetime.datetime.now()), "done 2st iteration of CRLs")
-    print(str(datetime.datetime.now()), "Start: creating CRLs with isolated loci")
+                del d_locus_crl_share[locusid]
+
+    chira_utilities.print_w_time("END: 2st iteration of CRLs")
+    chira_utilities.print_w_time("START: creating CRLs with isolated loci")
     # every locus that is in isolated_loci makes its own crl
     crl_index = len(d_crl_locus_reads)
     for locusid, l_locusreads in d_isolated_loci.items():
@@ -126,9 +130,8 @@ def create_crls(create_crls_too, bed, merged_bed, crl_file, crl_share, min_locus
         crl_index += 1
     d_locus_crl_share.clear()
 
-    print(str(datetime.datetime.now()), "End: creating CRLs with isolated loci")
+    chira_utilities.print_w_time("END: creating CRLs with isolated loci")
 
-    print(str(datetime.datetime.now()), "End: creating CRLs")
     print("There are a total of " + str(len(d_crl_locus_reads)) + " uniq crls")
 
     # read the segments BED once again to get the genomic positions
@@ -139,14 +142,13 @@ def create_crls(create_crls_too, bed, merged_bed, crl_file, crl_share, min_locus
             b = line.rstrip('\n').split('\t')
             pos = ':'.join([b[0], b[1], b[2], b[5]])
             desc = b[3].split(',')  # in the description column of the bed file,alignments are seperated by ';'
-            readid = desc[0]
+            segmentid = desc[0]
             transcriptid_pos = '\t'.join(desc[1:])
             # at this level reads have unique ids preceeded by a serialnumber
             # each read can have multiple alignements on same transcript
-            d_read_genomic_pos[transcriptid_pos+readid] = pos
+            d_read_genomic_pos[transcriptid_pos+segmentid] = pos
 
-    print(str(datetime.datetime.now()), "Start: Writing CRLs")
-    with open(crl_file, "w") as fh_groups_file:
+    with open(crl_file, "w") as fh_crl_file:
         # enumerate again because of above processing some crlids might be missing
         for crlid, d_crlloci in enumerate(d_crl_locus_reads.values()):
             if len(d_crlloci) > 1:
@@ -156,122 +158,110 @@ def create_crls(create_crls_too, bed, merged_bed, crl_file, crl_share, min_locus
                     locus_share = len(l_locusreads) / float(len(l_crlreads))
                 else:
                     locus_share = 1.0
-                for readid in sorted(l_locusreads):
-                    for transcriptid_pos in sorted(d_readlocus_transcripts[readid+str(locusid)]):
-                        entry = "\t".join([readid,
+                for segmentid in sorted(l_locusreads):
+                    for transcriptid_pos in sorted(d_readlocus_transcripts[segmentid+str(locusid)]):
+                        entry = "\t".join([segmentid,
                                            transcriptid_pos.split('\t')[0],
                                            str(locusid),
                                            str(crlid),
                                            '\t'.join(transcriptid_pos.split('\t')[1:]),
-                                           d_read_genomic_pos[transcriptid_pos+readid],
+                                           d_read_genomic_pos[transcriptid_pos+segmentid],
                                            l_locipos[locusid],
                                            "{:.4g}".format(locus_share)]
                                           )
-                        fh_groups_file.write(entry + "\n")
-    print(str(datetime.datetime.now()), "End: CRLs written")
+                        fh_crl_file.write(entry + "\n")
 
 
-def em(d_read_group_fractions, d_group_counts, em_threshold, i=1):
+def em(d_read_crl_shares, d_crl_counts, em_threshold, i=1):
     print("iteration: " + str(i))
-    d_read_group_fractions_new = {}
-    d_group_counts_new = {}
+    d_read_crl_shares_new = {}
+    d_crl_counts_new = {}
 
-    for readid in d_read_group_fractions.keys():
-        total_group_count = 0
-        d_read_group_fractions_new[readid] = {}
-        for groupid in d_read_group_fractions[readid]:
-            total_group_count += d_group_counts[groupid]
-        for groupid in d_read_group_fractions[readid]:
-            d_read_group_fractions_new[readid][groupid] = d_group_counts[groupid] / float(total_group_count)
-    d_read_group_fractions.clear()
+    for readid in d_read_crl_shares.keys():
+        total_crl_count = 0
+        d_read_crl_shares_new[readid] = {}
+        for crlid in d_read_crl_shares[readid]:
+            total_crl_count += d_crl_counts[crlid]
+        for crlid in d_read_crl_shares[readid]:
+            d_read_crl_shares_new[readid][crlid] = d_crl_counts[crlid] / float(total_crl_count)
+    d_read_crl_shares.clear()
 
-    for readid in d_read_group_fractions_new.keys():
-        for groupid in d_read_group_fractions_new[readid]:
-            if groupid not in d_group_counts_new:
-                d_group_counts_new[groupid] = 0
-            d_group_counts_new[groupid] += d_read_group_fractions_new[readid][groupid]
+    for readid in d_read_crl_shares_new.keys():
+        for crlid in d_read_crl_shares_new[readid]:
+            if crlid not in d_crl_counts_new:
+                d_crl_counts_new[crlid] = 0
+            d_crl_counts_new[crlid] += d_read_crl_shares_new[readid][crlid]
 
     equal = True
-    for groupid in d_group_counts.keys():
-        if abs(d_group_counts[groupid] - d_group_counts_new[groupid]) >= em_threshold:
+    for crlid in d_crl_counts.keys():
+        if abs(d_crl_counts[crlid] - d_crl_counts_new[crlid]) >= em_threshold:
             equal = False
             break
     if equal:
-        return d_read_group_fractions_new
+        return d_read_crl_shares_new
     else:
-        d_group_counts.clear()
+        d_crl_counts.clear()
         i += 1
-        return em(d_read_group_fractions_new, d_group_counts_new, em_threshold, i)
+        return em(d_read_crl_shares_new, d_crl_counts_new, em_threshold, i)
 
 
-def tpm(d_group_expression, d_group_locilen):
+def tpm(d_crl_expression, d_crl_loci_len):
     total_rpk = 0
-    d_group_tpm = defaultdict(float)
-    for groupid in sorted(d_group_expression.keys()):
-        crl_expression = d_group_expression[groupid]
-        crl_len = chira_utilities.median(sorted(d_group_locilen[groupid].values())) / 1000.0  # length in kbs
+    d_crl_tpm = defaultdict(float)
+    for crlid in sorted(d_crl_expression.keys()):
+        crl_expression = d_crl_expression[crlid]
+        crl_len = chira_utilities.median(sorted(d_crl_loci_len[crlid].values())) / 1000.0  # length in kbs
         rpk = crl_expression / crl_len
-        d_group_tpm[groupid] = rpk
+        d_crl_tpm[crlid] = rpk
         total_rpk += rpk
     millions_of_rpk = total_rpk / 1000000.0
-    for groupid in sorted(d_group_expression.keys()):
-        group_tpm = d_group_tpm[groupid] / millions_of_rpk
-        d_group_tpm[groupid] = group_tpm
-    return d_group_tpm
+    for crlid in sorted(d_crl_expression.keys()):
+        crl_tpm = d_crl_tpm[crlid] / millions_of_rpk
+        d_crl_tpm[crlid] = crl_tpm
+    return d_crl_tpm
 
 
 def quantify_crls(crl_file, em_threshold):
-    d_read_group_fractions = defaultdict(lambda: defaultdict(float))
-    d_group_locilen = defaultdict(lambda: defaultdict(int))
-    d_group_expression = defaultdict(float)
+    d_read_crl_shares = defaultdict(lambda: defaultdict(float))
+    d_crl_loci_len = defaultdict(lambda: defaultdict(int))
+    d_crl_expression = defaultdict(float)
 
-    print(str(datetime.datetime.now()), "Start: preparing EM")
     fh_crl_file = open(crl_file, "r")
     for line in fh_crl_file:
         f = line.rstrip("\n").split("\t")
         # consider the segment id and quantify individula segments than whole reads
         readid = f[0]
         locusid = f[2]
-        groupid = f[3]
+        crlid = f[3]
         pos = f[9].split(':')
         locuslength = int(pos[-2]) - int(pos[-3]) + 1
         # a single locus can belong to multiple crls
         # one read can be part of multiple crls
-        d_read_group_fractions[readid][groupid] = 0
-        d_group_locilen[groupid][locusid] = locuslength
+        d_read_crl_shares[readid][crlid] = 0
+        d_crl_loci_len[crlid][locusid] = locuslength
     fh_crl_file.close()
 
-    d_group_counts = {}
-    for readid in d_read_group_fractions.keys():
-        for groupid in d_read_group_fractions[readid].keys():
-            d_read_group_fractions[readid][groupid] = 1 / float(len(d_read_group_fractions[readid]))
-            if groupid not in d_group_counts:
-                d_group_counts[groupid] = 0
-            d_group_counts[groupid] += d_read_group_fractions[readid][groupid]
+    d_crl_counts = {}
+    for readid in d_read_crl_shares.keys():
+        for crlid in d_read_crl_shares[readid].keys():
+            d_read_crl_shares[readid][crlid] = 1 / float(len(d_read_crl_shares[readid]))
+            if crlid not in d_crl_counts:
+                d_crl_counts[crlid] = 0
+            d_crl_counts[crlid] += d_read_crl_shares[readid][crlid]
 
-    print(str(datetime.datetime.now()), "End: preparing EM")
-    print(str(datetime.datetime.now()), "Start: recursing EM")
     sys.setrecursionlimit(10000)
-    d_res = em(d_read_group_fractions, d_group_counts, em_threshold)
-    print(str(datetime.datetime.now()), "End: recursing EM")
+    d_res = em(d_read_crl_shares, d_crl_counts, em_threshold)
     for readid in d_res.keys():
-        # now d_read_groups should contain only multi mapped reads because because
+        # now d_read_crls should contain only multi mapped reads because because
         # uniquely mapped reads were already removed
         # set() because a read can occur 2 times at a locus in file with 2 tx ids
         # one read can be part of multiple crls
-        for groupid in d_res[readid]:
-            d_group_expression[groupid] += d_res[readid][groupid]
+        for crlid in d_res[readid]:
+            d_crl_expression[crlid] += d_res[readid][crlid]
 
-    d_group_tpm = tpm(d_group_expression, d_group_locilen)
+    d_crl_tpm = tpm(d_crl_expression, d_crl_loci_len)
 
-    return d_res, d_group_tpm
-
-
-def score_float(x):
-    x = float(x)
-    if x < 0.0 or x > 1.0:
-        raise argparse.ArgumentTypeError("%r not in range [0.0, 1.0]" % (x,))
-    return x
+    return d_res, d_crl_tpm
 
 
 if __name__ == "__main__":
@@ -289,7 +279,7 @@ if __name__ == "__main__":
     parser.add_argument('-o', '--outdir', action='store', dest='outdir', required=True, metavar='',
                         help='Output file containing merged alignments')
 
-    parser.add_argument('-cs', '--crl_share', action='store', type=score_float, default=0.7, metavar='',
+    parser.add_argument('-cs', '--crl_share', action='store', type=chira_utilities.score_float, default=0.7, metavar='',
                         dest='crl_share',
                         help='Minimum fraction of reads of a locus that must overlap with all CRL loci '
                              'inorder to merge it into that CRL.')
@@ -301,15 +291,15 @@ if __name__ == "__main__":
                              'CRLs of random multimappings Also consider setting the --crl_share option '
                              'along with this')
 
-    parser.add_argument('-e', '--em_threshold', action='store', type=score_float, default=1, metavar='',
+    parser.add_argument('-e', '--em_threshold', action='store', type=chira_utilities.score_float, default=1, metavar='',
                         dest='em_thresh',
                         help='The maximum difference of transcripts expression between two consecutive iterations '
                              'of EM algorithm to converge.')
 
-    parser.add_argument("-crl", '--create_crls_too', action='store_true', dest='create_crls_too',
+    parser.add_argument("-crl", '--build_crls_too', action='store_true', dest='build_crls_too',
                         help="Create CRLs too")
 
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.1.5')
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.2.0')
 
     args = parser.parse_args()
 
@@ -319,12 +309,17 @@ if __name__ == "__main__":
     print('Minimum locus size                   : ' + str(args.min_locus_size))
     print('CRL share                            : ' + str(args.crl_share))
     print('EM threshold                         : ' + str(args.em_thresh))
-    print('Create CRLs too                      : ' + str(args.create_crls_too))
+    print('Create CRLs too                      : ' + str(args.build_crls_too))
     print("===================================================================")
 
-    create_crls(args.create_crls_too, args.bed, args.merged_bed,
-                os.path.join(args.outdir, 'loci.txt'), args.crl_share, args.min_locus_size)
+    chira_utilities.print_w_time("START: Build CRLs")
+    build_crls(args.build_crls_too, args.bed, args.merged_bed,
+               os.path.join(args.outdir, 'loci.txt'), args.crl_share, args.min_locus_size)
+    chira_utilities.print_w_time("END: Build CRLs")
+    chira_utilities.print_w_time("START: Quantify CRLs")
     d_read_crl_fractions, d_crl_tpms = quantify_crls(os.path.join(args.outdir, 'loci.txt'), args.em_thresh)
+    chira_utilities.print_w_time("END: Quantify CRLs")
+    chira_utilities.print_w_time("START: Write CRLs")
     with open(os.path.join(args.outdir, 'loci.txt')) as fh_in:
         with open(os.path.join(args.outdir, 'loci.counts'), "w") as fh_out:
             for l in fh_in:
@@ -334,4 +329,5 @@ if __name__ == "__main__":
                 fh_out.write("\t".join([l.strip("\n"),
                                         "{:.4g}".format(d_read_crl_fractions[read_id][crl_id]),
                                         "{:.4g}".format(d_crl_tpms[crl_id])]) + "\n")
+    chira_utilities.print_w_time("END: Write CRLs")
     os.remove(os.path.join(args.outdir, 'loci.txt'))


### PR DESCRIPTION
chira_map.py: 1) remove the step of extracting non-chimeric reads 2) only map and merge BAM files 3) extract only unmapped/not properly mapped 4) sort BED file to allow new merging 4) cosider whole alignment length to choose best alignment 5) no more multiprocessing used except for mapping system calls
chira_merge.py: 1) work with BED file that is sorted by read name in 4th column 2) Need reference fasta files to check for chimeric reads 3) option to merge chimeric reads only 3) Simplify transcript_to_genomic_pos function
chira_quantify.py: 1) small variable naming tweaks
chira_extract.py: 1) for each entry, the order of the interacting partners are sorted by the order of the given reference fasta in case of split reference or by name of the transcript in case of single reference fasta 2) use subprocess to capture the warning messages from fastaFromBed command and output only unique messages
chira_utilities.py: 1) added print_w_time funtion to print to stdout with timestamp 2) score_float function moved here