### PR TITLE
1) Ignore blockbuster clusters. Merge overlapping blocks

### DIFF
--- a/chira_map.py
+++ b/chira_map.py
@@ -297,7 +297,7 @@ if __name__ == "__main__":
     parser.add_argument("-h1", '--nhits1', action='store', type=int, default=50, metavar='',
                         dest='nhits1',
                         help='Number of allowed multi hits per read')
-output
+
     parser.add_argument("-h2", '--nhits2', action='store', type=int, default=100, metavar='',
                         dest='nhits2',
                         help='Number of allowed multi hits per read in 2nd iteration')


### PR DESCRIPTION
2) Report each locus pair only once in interaction summary
3) Sort interaction summary by read count